### PR TITLE
[WIP] Remove JSON preprocessor to leave this job to another plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,15 +125,5 @@ module.exports = {
         };
       }
     }
-  },
-  processors: {
-    ".json": {
-      preprocess(text) {
-        return [`var json = ${text}`];
-      },
-      postprocess(messages, fileName) {
-        return messages[0];
-      }
-    }
   }
 };


### PR DESCRIPTION
Have an issue when use this plugin together with https://github.com/ota-meshi/eslint-plugin-jsonc . The problem is that this plugin defines its own processor for JSON files when it shouldn't. We need to remove this and leave preprocessing to dedicated plugins. `eslint-plugin-jsonc` particularly will inherit all rules applied to JS tokens to JSON tokens which means that `eslint-plugin-no-secrets` will naturally work in JSON. And also it will work in JSONC, JSON5 and JSON6 which this plugin doesn't support

The error thrown during linting JSON files only:

```
error: Parsing error: Unexpected token var at src\configs\vue.config.json:1:3:
```